### PR TITLE
feat(fork): accept setup macro parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rusty-forkfork"
 keywords = ["testing", "process", "fork"]
 categories = ["development-tools::testing"]
 exclude = ["/gen-readme.sh", "/readme-*.md"]
-edition = "2018"
+edition = "2021"
 
 description = """
 Cross-platform library for running Rust tests in sub-processes using a
@@ -18,7 +18,7 @@ fork-like interface.
 
 [dependencies]
 fnv = "1.0"
-quick-error = "1.2"
+quick-error = "2.0"
 tempfile = "3.0"
 wait-timeout = { version = "0.2", optional = true }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ quick_error! {
         /// Spawning a subprocess failed.
         SpawnError(err: io::Error) {
             from()
-            cause(err)
+            source(err)
             display("Spawn failed: {}", err)
         }
     }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -382,7 +382,7 @@ mod test {
             rusty_fork_id!(),
             |_| (),
             |child, _| child.wait().unwrap(),
-            || panic!("testing a panic, nothing to see here"),
+            || -> () { panic!("testing a panic, nothing to see here") },
         )
         .unwrap();
         assert_eq!(70, status.code().unwrap());


### PR DESCRIPTION
This change allows specifying as a macro parameter a setup function to change environment and possibly other properties of the Command to be executed.

It is sometimes desirable to set additional environment variables to child processes before running them,
e.g. when testing dynamically-loaded cdylibs and
needing to set the library search path to a folder within the project.

Additionally, it solves a few compiler warnings
and bumps the Rust edition to 2021.